### PR TITLE
Fix CI without lockfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,5 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: 'npm'
-      - run: npm ci
+      - run: npm install
       - run: npm run build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '18'
-          cache: 'npm'
-      - run: npm ci
+      - run: npm install
       - run: npm run build
 


### PR DESCRIPTION
## Summary
- remove npm cache requirement in CI workflows
- use `npm install` instead of `npm ci` since there's no lock file

## Testing
- `npm run build`