### PR TITLE
Add tests with Makefile entry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: tests
+
+tests:
+	npm test

--- a/README.md
+++ b/README.md
@@ -36,6 +36,20 @@ npm start
 
 The server listens on `MCP_SERVER_PORT` (5005 by default).
 
+## Running tests
+
+The project includes a small test suite. Run it using `npm`:
+
+```bash
+npm test
+```
+
+Alternatively you can use `make`:
+
+```bash
+make tests
+```
+
 ### Docker
 
 Alternatively you can build and run the container image:

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc",
-    "start": "node dist/index.js"
+    "start": "node dist/index.js",
+    "test": "npm run build && node --test"
   },
   "dependencies": {},
   "devDependencies": {

--- a/test/mcp.test.js
+++ b/test/mcp.test.js
@@ -1,0 +1,66 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import http from 'node:http';
+import { createServer } from '../dist/mcp.js';
+
+async function startServer(tools) {
+  const server = createServer({ tools });
+  await new Promise(res => server.listen(0, res));
+  const port = server.address().port;
+  return { server, port };
+}
+
+async function request(port, body, options = {}) {
+  return await new Promise((resolve, reject) => {
+    const req = http.request({
+      method: options.method || 'POST',
+      hostname: 'localhost',
+      port,
+      path: options.path || '/',
+      headers: {
+        'Content-Type': 'application/json'
+      }
+    }, res => {
+      let data = '';
+      res.on('data', chunk => data += chunk);
+      res.on('end', () => resolve({ status: res.statusCode, body: data }));
+    });
+    req.on('error', reject);
+    if (body !== undefined) {
+      req.write(JSON.stringify(body));
+    }
+    req.end();
+  });
+}
+
+test('successful tool execution', async () => {
+  const tools = [{
+    name: 'hello',
+    description: 'Greets the user',
+    inputs: { name: 'string' },
+    run: ({ name }) => `Hello ${name}`
+  }];
+  const { server, port } = await startServer(tools);
+  const res = await request(port, { tool: 'hello', args: { name: 'World' } });
+  server.close();
+
+  assert.equal(res.status, 200);
+  const result = JSON.parse(res.body).result;
+  assert.equal(result, 'Hello World');
+});
+
+test('unknown tool returns 404', async () => {
+  const { server, port } = await startServer([]);
+  const res = await request(port, { tool: 'missing' });
+  server.close();
+
+  assert.equal(res.status, 404);
+});
+
+test('non-POST request returns 404', async () => {
+  const { server, port } = await startServer([]);
+  const res = await request(port, undefined, { method: 'GET' });
+  server.close();
+
+  assert.equal(res.status, 404);
+});


### PR DESCRIPTION
## Summary
- add a simple Makefile with `tests` target
- implement a basic test suite for the MCP server
- document how to run the new tests
- wire up `npm test` to build and run the tests

## Testing
- `npm test`
- `make tests`
