### PR TITLE
Add Docker Compose example and GHCR publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,31 @@
+name: Publish Container
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v2
+      - uses: docker/setup-buildx-action@v2
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set lowercase owner
+        run: echo "OWNER=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+      - uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Containerfile
+          push: true
+          tags: ghcr.io/${{ env.OWNER }}/mcp-actual-server:latest

--- a/README.md
+++ b/README.md
@@ -61,3 +61,35 @@ podman run -p 5005:5005 \
   -e ACTUAL_API_KEY=secret \
   mcp-actual-server
 ```
+
+The container image is automatically built by GitHub Actions and published to
+the GitHub Container Registry. You can pull it without building locally:
+
+```bash
+docker pull ghcr.io/your-username/mcp-actual-server:latest
+```
+When replacing `your-username`, use your GitHub username in lowercase because
+GHCR repository names must be lowercase.
+
+### Docker Compose
+
+You can also run the server using `docker compose`:
+
+```yaml
+version: "3"
+services:
+  mcp-actual:
+    image: ghcr.io/your-username/mcp-actual-server:latest
+    ports:
+      - "5005:5005"
+    environment:
+      ACTUAL_API_URL: http://your-actual:5006
+      ACTUAL_API_KEY: secret
+      MCP_SERVER_PORT: 5005
+```
+
+Start the service with:
+
+```bash
+docker compose up
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: "3"
+services:
+  mcp-actual:
+    # Replace "your-username" with your GitHub username in lowercase
+    image: ghcr.io/your-username/mcp-actual-server:latest
+    ports:
+      - "5005:5005"
+    environment:
+      ACTUAL_API_URL: http://your-actual:5006
+      ACTUAL_API_KEY: secret
+      MCP_SERVER_PORT: 5005


### PR DESCRIPTION
## Summary
- add `docker-compose.yml` with environment and ports
- document Docker Compose usage and note GHCR container image
- create GitHub Actions workflow to publish container to GitHub Packages
- ensure GHCR tag uses lowercase owner

## Testing
- `npm test`
